### PR TITLE
Fix star parsing and lint errors

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -1,8 +1,9 @@
 package gitbot
 
+// Asset usually refers to a downloadable release
 type Asset struct {
-	Url           string `json:"url"`
-	Id            int    `json:"id"`
+	URL           string `json:"url"`
+	ID            int    `json:"id"`
 	Name          string `json:"name"`
 	Label         string `json:"label"`
 	State         string `json:"state"`

--- a/commit_comment.go
+++ b/commit_comment.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 )
 
+// CommitComment is a bespoke comment on a commit
 type CommitComment struct {
-	HtmlUrl  string `json:"html_url"`
-	Url      string `json:"url"`
-	Id       int    `json:"id"`
+	HTMLURL  string `json:"html_url"`
+	URL      string `json:"url"`
+	ID       int    `json:"id"`
 	Body     string `json:"body"`
 	Path     string `json:"path"`
 	Position int    `json:"position"`
 	Line     int    `json:"line"`
-	CommitId string `json:"commit_id"`
+	CommitID string `json:"commit_id"`
 	User     *User  `json:"user"`
 	//CreatedAt NullTime `json:"created_at"`
 	//UpdatedAt NullTime `json:"updated_at"`
@@ -20,7 +21,7 @@ type CommitComment struct {
 
 func (s CommitComment) String() string {
 	if s.Path != "" {
-		return fmt.Sprintf("on %s:%d by %s %s", s.Path, s.Line, s.User, s.HtmlUrl)
+		return fmt.Sprintf("on %s:%d by %s %s", s.Path, s.Line, s.User, s.HTMLURL)
 	}
-	return fmt.Sprintf("by %s %s", s.User, s.HtmlUrl)
+	return fmt.Sprintf("by %s %s", s.User, s.HTMLURL)
 }

--- a/gitbot_test.go
+++ b/gitbot_test.go
@@ -17,12 +17,12 @@ func (Mockshortener) Shorten(url string) (string, error) {
 }
 
 // this function would be in the gitio lib
-func ShortenMock(url string) (string, error) {
+func shortenMock(url string) (string, error) {
 	return url[len(url)/2:], nil
 }
 
 func init() {
-	ShortURL = ShortenFunc(ShortenMock)
+	shortURL = shortenFunc(shortenMock)
 	cinotify.Logger = log.New(os.Stdout, "Log: ", log.Llongfile)
 }
 

--- a/issue.go
+++ b/issue.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 )
 
+// Issue object from github api
 type Issue struct {
 	User        *User        `json:"user"`
 	Assignee    *User        `json:"assignee"`
@@ -11,8 +12,8 @@ type Issue struct {
 	PullRequest *PullRequest `json:"pull_request"`
 	ClosedBy    *User        `json:"closed_by"`
 	Labels      []*Label     `json:"labels"`
-	Url         string       `json:"url"`
-	HtmlUrl     string       `json:"html_url"`
+	URL         string       `json:"url"`
+	HTMLURL     string       `json:"html_url"`
 	Number      int          `json:"number"`
 	State       string       `json:"state"`
 	Title       string       `json:"title"`

--- a/issue_comment.go
+++ b/issue_comment.go
@@ -4,16 +4,17 @@ import (
 	"fmt"
 )
 
+// IssueComment is a comment on an issue
 type IssueComment struct {
 	User    *User  `json:"user"`
-	Id      int    `json:"id"`
-	Url     string `json:"url"`
-	HtmlUrl string `json:"html_url"`
+	ID      int    `json:"id"`
+	URL     string `json:"url"`
+	HTMLURL string `json:"html_url"`
 	Body    string `json:"body"`
 	//CreatedAt NullTime `json:"created_at"`
 	//UpdatedAt NullTime `json:"updated_at"`
 }
 
 func (s IssueComment) String() string {
-	return fmt.Sprintf("%s", s.HtmlUrl)
+	return fmt.Sprintf("%s", s.HTMLURL)
 }

--- a/label.go
+++ b/label.go
@@ -1,7 +1,8 @@
 package gitbot
 
+// Label for a repository
 type Label struct {
-	Url   string `json:"url"`
+	URL   string `json:"url"`
 	Name  string `json:"name"`
 	Color string `json:"color"`
 }

--- a/link.go
+++ b/link.go
@@ -1,5 +1,6 @@
 package gitbot
 
+// Link to a resource
 type Link struct {
 	Href string `json:"href"`
 }

--- a/links.go
+++ b/links.go
@@ -1,8 +1,9 @@
 package gitbot
 
+// Links to various resources
 type Links struct {
 	Self           *Link `json:"self"`
-	Html           *Link `json:"html"`
+	HTML           *Link `json:"html"`
 	Issue          *Link `json:"issue"`
 	Comments       *Link `json:"comments"`
 	ReviewComments *Link `json:"review_comments"`

--- a/milestone.go
+++ b/milestone.go
@@ -1,8 +1,9 @@
 package gitbot
 
+// Milestone for a repository
 type Milestone struct {
 	Creator      *User  `json:"creator"`
-	Url          string `json:"url"`
+	URL          string `json:"url"`
 	Number       int    `json:"number"`
 	State        string `json:"state"`
 	Title        string `json:"title"`

--- a/nulltime.go
+++ b/nulltime.go
@@ -5,11 +5,13 @@ import (
 	"time"
 )
 
+// NullTime allows us to parse time OR a null from JSON
 type NullTime struct {
 	Valid bool
 	Time  time.Time
 }
 
+// MarshalJSON turns null time into json
 func (n NullTime) MarshalJSON() ([]byte, error) {
 	if !n.Valid {
 		return []byte(`null`), nil
@@ -18,6 +20,7 @@ func (n NullTime) MarshalJSON() ([]byte, error) {
 	return []byte(n.Time.Format(time.RFC3339)), nil
 }
 
+// UnmarshalJSON parses time from json
 func (n *NullTime) UnmarshalJSON(data []byte) error {
 	str := strings.Trim(string(data), `"`)
 
@@ -35,6 +38,7 @@ func (n *NullTime) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// String for fmt.Stringer
 func (n NullTime) String() string {
 	if !n.Valid {
 		return ""

--- a/organization.go
+++ b/organization.go
@@ -1,8 +1,9 @@
 package gitbot
 
+// Organization in github
 type Organization struct {
 	Login     string `json:"login"`
-	Id        int    `json:"id"`
-	Url       string `json:"url"`
-	AvatarUrl string `json:"avatar_url"`
+	ID        int    `json:"id"`
+	URL       string `json:"url"`
+	AvatarURL string `json:"avatar_url"`
 }

--- a/page.go
+++ b/page.go
@@ -1,9 +1,10 @@
 package gitbot
 
+// Page refers to github pages
 type Page struct {
 	PageName string `json:"page_name"` // The name of the page.
 	Title    string `json:"title"`     // The current page title.
 	Action   string `json:"action"`    // The action that was performed on the page. Can be “created” or “edited”.
 	SHA      string `json:"sha"`       // The latest commit SHA of the page.
-	HtmlUrl  string `json:"html_url"`  // Points to the HTML wiki page.
+	HTMLURL  string `json:"html_url"`  // Points to the HTML wiki page.
 }

--- a/payload_commit_comment.go
+++ b/payload_commit_comment.go
@@ -2,6 +2,7 @@ package gitbot
 
 import "fmt"
 
+// PayloadCommitComment is a commit comment
 type PayloadCommitComment struct {
 	Comment *CommitComment `json:"comment"`    // The comment itself.
 	Repo    *Repository    `json:"repository"` // Repo

--- a/payload_create.go
+++ b/payload_create.go
@@ -2,6 +2,7 @@ package gitbot
 
 import "fmt"
 
+// PayloadCreate for creating repositories/branches
 type PayloadCreate struct {
 	Ref          string      `json:"ref"`
 	RefType      string      `json:"ref_type"`

--- a/payload_delete.go
+++ b/payload_delete.go
@@ -2,6 +2,7 @@ package gitbot
 
 import "fmt"
 
+// PayloadDelete for deleting refs/tags/branches
 type PayloadDelete struct {
 	RefType string      `json:"ref_type"`   //The object that was deleted. Can be “branch” or “tag”.
 	Ref     string      `json:"ref"`        //The full git ref.

--- a/payload_fork.go
+++ b/payload_fork.go
@@ -2,6 +2,7 @@ package gitbot
 
 import "fmt"
 
+// PayloadFork when someone forks a repo
 type PayloadFork struct {
 	Forkee *Repository `json:"forkee"`     // The created repository.
 	Repo   *Repository `json:"repository"` // Repo

--- a/payload_gollum.go
+++ b/payload_gollum.go
@@ -2,6 +2,7 @@ package gitbot
 
 import "fmt"
 
+// PayloadGollum for generating github pages
 type PayloadGollum struct {
 	Pages  []*Page     `json:"pages"`      // The pages that were updated.
 	Repo   *Repository `json:"repository"` // Repo

--- a/payload_issue_comment.go
+++ b/payload_issue_comment.go
@@ -2,6 +2,7 @@ package gitbot
 
 import "fmt"
 
+// PayloadIssueComment when someone comments on an issue
 type PayloadIssueComment struct {
 	Action  string        `json:"action"`     // The action that was performed on the comment. Currently, can only be “created”.
 	Issue   *Issue        `json:"issue"`      // The issue the comment belongs to.

--- a/payload_issues.go
+++ b/payload_issues.go
@@ -2,6 +2,7 @@ package gitbot
 
 import "fmt"
 
+// PayloadIssues for state changes on issues
 type PayloadIssues struct {
 	Action string      `json:"action"`     // The action that was performed. Can be one of “opened”, “closed”, or “reopened”.
 	Issue  *Issue      `json:"issue"`      // The issue itself.

--- a/payload_member.go
+++ b/payload_member.go
@@ -2,6 +2,7 @@ package gitbot
 
 import "fmt"
 
+// PayloadMember when membership of an repo changes
 type PayloadMember struct {
 	Member *User       `json:"member"`     // The user that was added.
 	Action string      `json:"action"`     // The action that was performed. Currently, can only be “added”.

--- a/payload_pull_request.go
+++ b/payload_pull_request.go
@@ -2,6 +2,7 @@ package gitbot
 
 import "fmt"
 
+// PayloadPullRequest when a PR gets created
 type PayloadPullRequest struct {
 	Action      string       `json:"action"`       // The action that was performed. Can be one of “opened”, “closed”, “synchronize”, or “reopened”.
 	Number      int          `json:"number"`       // The pull request number.

--- a/payload_release.go
+++ b/payload_release.go
@@ -2,6 +2,7 @@ package gitbot
 
 import "fmt"
 
+// PayloadRelease when a release is published
 type PayloadRelease struct {
 	Action  string      `json:"action"`     // The action that was performed. Currently, can only be “published”.
 	Release *Release    `json:"release"`    // The release itself.

--- a/payload_star.go
+++ b/payload_star.go
@@ -1,0 +1,23 @@
+package gitbot
+
+import "fmt"
+
+// PayloadStar when a star is added or removed
+// StarredAt will be nil when it's a delete action
+// Currently Github is confusing and sends this as well when a star occurs
+type PayloadStar struct {
+	Action    string      `json:"action"`     // The action that was performed: created | deleted
+	StarredAt NullTime    `json:"starred_at"` // Null when deleted
+	Repo      *Repository `json:"repository"` // Repo
+	Sender    *User       `json:"sender"`     // Sender
+}
+
+func (s PayloadStar) String() string {
+	switch s.Action {
+	case "created":
+		return fmt.Sprintf("[%s] was starred by %s", s.Repo, s.Sender)
+	case "deleted":
+		return fmt.Sprintf("[%s] was unstarred by %s", s.Repo, s.Sender)
+	}
+	return fmt.Sprintf("[%s] %s has performed an unknown starring action", s.Repo, s.Sender)
+}

--- a/payload_team_add.go
+++ b/payload_team_add.go
@@ -2,6 +2,7 @@ package gitbot
 
 import "fmt"
 
+// PayloadTeamAdd when a team is added to
 type PayloadTeamAdd struct {
 	Team   *Team       `json:"team"`       // The team that was modified.
 	User   *User       `json:"user"`       // The user that was added to this team.

--- a/payload_watch.go
+++ b/payload_watch.go
@@ -2,6 +2,8 @@ package gitbot
 
 import "fmt"
 
+// PayloadWatch when a watcher is added
+// Currently Github is confusing and sends this as well when a star occurs
 type PayloadWatch struct {
 	Action string      `json:"action"`     // The action that was performed. Currently, can only be started.
 	Repo   *Repository `json:"repository"` // Repo

--- a/permissions.go
+++ b/permissions.go
@@ -1,5 +1,6 @@
 package gitbot
 
+// Permissions in github
 type Permissions struct {
 	Admin bool `json:"admin"`
 	Push  bool `json:"push"`

--- a/pull_request.go
+++ b/pull_request.go
@@ -2,22 +2,23 @@ package gitbot
 
 import "fmt"
 
+// PullRequest object from github API
 type PullRequest struct {
 	Head              *Head  `json:"head"`
 	Base              *Head  `json:"base"`
 	Links             *Links `json:"_links"`
 	User              *User  `json:"user"`
 	MergedBy          *User  `json:"merged_by"`
-	Url               string `json:"url"`
-	HtmlUrl           string `json:"html_url"`
-	DiffUrl           string `json:"diff_url"`
-	PatchUrl          string `json:"patch_url"`
-	IssueUrl          string `json:"issue_url"`
-	CommitsUrl        string `json:"commits_url"`
-	ReviewCommentsUrl string `json:"review_comments_url"`
-	ReviewCommentUrl  string `json:"review_comment_url"`
-	CommentsUrl       string `json:"comments_url"`
-	StatusesUrl       string `json:"statuses_url"`
+	URL               string `json:"url"`
+	HTMLURL           string `json:"html_url"`
+	DiffURL           string `json:"diff_url"`
+	PatchURL          string `json:"patch_url"`
+	IssueURL          string `json:"issue_url"`
+	CommitsURL        string `json:"commits_url"`
+	ReviewCommentsURL string `json:"review_comments_url"`
+	ReviewCommentURL  string `json:"review_comment_url"`
+	CommentsURL       string `json:"comments_url"`
+	StatusesURL       string `json:"statuses_url"`
 	Number            int    `json:"number"`
 	State             string `json:"state"`
 	Title             string `json:"title"`
@@ -37,5 +38,5 @@ type PullRequest struct {
 }
 
 func (s PullRequest) String() string {
-	return fmt.Sprintf("#%v %s (%s)", s.Number, s.Title, s.HtmlUrl)
+	return fmt.Sprintf("#%v %s (%s)", s.Number, s.Title, s.HTMLURL)
 }

--- a/pull_request_review_comment.go
+++ b/pull_request_review_comment.go
@@ -1,6 +1,6 @@
 package gitbot
 
-// TODO make PullRequestComment struct...
+// PullRequestReviewComment review for pull requests
 type PullRequestReviewComment struct {
 	Comment *IssueComment `json:"comment"`    // The comment itself
 	Repo    *Repository   `json:"repository"` // Repo

--- a/push_funcs.go
+++ b/push_funcs.go
@@ -6,29 +6,32 @@ import (
 )
 
 const (
-	PUSH_MSG = "[%s] %s pushed %v commits to %s %s"
+	fmtPushMsg = "[%s] %s pushed %v commits to %s %s"
 )
 
+// User that pushed
 func (c PushCommit) User() string {
 	if c.Committer == nil || c.Committer.Username == "" {
-		return UNKNOWN
+		return Unknown
 	}
 	return c.Committer.Username
 }
 
-func (c PushCommit) ShortId() string {
-	if c.Id == "" {
-		return UNKNOWN
+// ShortID is the short git commit ID
+func (c PushCommit) ShortID() string {
+	if c.ID == "" {
+		return Unknown
 	}
-	if len(c.Id) < 7 {
-		return c.Id
+	if len(c.ID) < 7 {
+		return c.ID
 	}
-	return c.Id[:7]
+	return c.ID[:7]
 }
 
+// Msg is the last commit message from the pushed commits
 func (c PushCommit) Msg() string {
 	if c.Message == "" {
-		return NOMSG
+		return NoMsg
 	}
 
 	n := strings.Index(c.Message, "\n")
@@ -40,21 +43,24 @@ func (c PushCommit) Msg() string {
 }
 
 func (c PushCommit) String() string {
-	return fmt.Sprintf("%s: %s: %s", c.ShortId(), c.User(), c.Msg())
+	return fmt.Sprintf("%s: %s: %s", c.ShortID(), c.User(), c.Msg())
 }
 
+// Branch of the push
 func (pl PushPayload) Branch() string {
 	refs := strings.Split(pl.Ref, "/")
 	return refs[len(refs)-1]
 }
 
+// Name of the repo
 func (pl PushPayload) Name() string {
 	if pl.Repository == nil {
-		return UNKNOWN
+		return Unknown
 	}
 	return pl.Repository.String()
 }
 
+// NumCommits that occurred in the push
 func (pl PushPayload) NumCommits() int {
 	if pl.Commits == nil {
 		return 0
@@ -62,19 +68,20 @@ func (pl PushPayload) NumCommits() int {
 	return len(pl.Commits)
 }
 
+// PusherName is the person who pushed
 func (pl PushPayload) PusherName() string {
 	if pl.Pusher == nil || pl.Pusher.Name == "" {
-		return UNKNOWN
+		return Unknown
 	}
 	return pl.Pusher.Name
 }
 
 func (pl PushPayload) String() (out string) {
-	comp, err := ShortURL.Shorten(pl.Compare)
+	comp, err := shortURL.Shorten(pl.Compare)
 	if err != nil {
 		comp = pl.Compare
 	}
-	out = fmt.Sprintf(PUSH_MSG, pl.Name(), pl.PusherName(),
+	out = fmt.Sprintf(fmtPushMsg, pl.Name(), pl.PusherName(),
 		pl.NumCommits(), pl.Branch(), comp)
 	return
 }

--- a/push_structs.go
+++ b/push_structs.go
@@ -1,6 +1,6 @@
-//Structures for git
 package gitbot
 
+// PushCommit is a commit in a push
 type PushCommit struct {
 	Added     []string
 	Modified  []string
@@ -8,28 +8,30 @@ type PushCommit struct {
 	Author    *PushPerson
 	Committer *PushPerson
 	Distinct  bool
-	Id        string
+	ID        string
 	Message   string
 	//Timestamp *NullTime
-	Url string
+	URL string
 }
 
+// PushPerson is the person who pushed
 type PushPerson struct {
 	Email    string
 	Name     string
 	Username string
 }
 
+// PushPayload comes from a push to a branch
 type PushPayload struct {
-	Before      string
-	After       string
-	Ref         string
-	Compare     string
-	Created     bool
-	Deleted     bool
-	Forced      bool
-	Commits     []*PushCommit
-	Head_commit *PushCommit
-	Pusher      *PushPerson //may not have Username, beware
-	Repository  *Repository
+	Before     string
+	After      string
+	Ref        string
+	Compare    string
+	Created    bool
+	Deleted    bool
+	Forced     bool
+	Commits    []*PushCommit
+	HeadCommit *PushCommit
+	Pusher     *PushPerson //may not have Username, beware
+	Repository *Repository
 }

--- a/release.go
+++ b/release.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 )
 
+// Release object
 type Release struct {
-	Url             string `json:"url"`
-	HtmlUrl         string `json:"html_url"`
-	AssetsUrl       string `json:"assets_url"`
-	UploadUrl       string `json:"upload_url"`
-	TarballUrl      string `json:"tarball_url"`
-	ZipballUrl      string `json:"zipball_url"` // lol zipball
-	Id              int    `json:"id"`
+	URL             string `json:"url"`
+	HTMLURL         string `json:"html_url"`
+	AssetsURL       string `json:"assets_url"`
+	UploadURL       string `json:"upload_url"`
+	TarballURL      string `json:"tarball_url"`
+	ZipballURL      string `json:"zipball_url"` // lol zipball
+	ID              int    `json:"id"`
 	TagName         string `json:"tag_name"`
 	TargetCommitish string `json:"target_commitish"`
 	Name            string `json:"name"`
@@ -25,5 +26,5 @@ type Release struct {
 }
 
 func (s Release) String() string {
-	return fmt.Sprintf("%s %s", s.Name, s.HtmlUrl)
+	return fmt.Sprintf("%s %s", s.Name, s.HTMLURL)
 }

--- a/repository.go
+++ b/repository.go
@@ -1,20 +1,21 @@
 package gitbot
 
+// Repository is the general repository object in the github API
 type Repository struct {
 	Owner           *User  `json:"owner"`
-	Id              int    `json:"id"`
+	ID              int    `json:"id"`
 	Name            string `json:"name"`
 	FullName        string `json:"full_name"`
 	Description     string `json:"description"`
 	Private         bool   `json:"private"`
 	Fork            bool   `json:"fork"`
-	Url             string `json:"url"`
-	HtmlUrl         string `json:"html_url"`
-	CloneUrl        string `json:"clone_url"`
-	GitUrl          string `json:"git_url"`
-	SshUrl          string `json:"ssh_url"`
-	SvnUrl          string `json:"svn_url"`
-	MirrorUrl       string `json:"mirror_url"`
+	URL             string `json:"url"`
+	HTMLURL         string `json:"html_url"`
+	CloneURL        string `json:"clone_url"`
+	GitURL          string `json:"git_url"`
+	SSHURL          string `json:"ssh_url"`
+	SVNURL          string `json:"svn_url"`
+	MirrorURL       string `json:"mirror_url"`
 	Homepage        string `json:"homepage"`
 	Language        string `json:"language"`
 	ForksCount      int    `json:"forks_count"`

--- a/team.go
+++ b/team.go
@@ -1,9 +1,10 @@
 package gitbot
 
+// Team object from github api
 type Team struct {
-	Url          string        `json:"url"`
+	URL          string        `json:"url"`
 	Name         string        `json:"name"`
-	Id           string        `json:"id"`
+	ID           string        `json:"id"`
 	Permission   string        `json:"permission"`
 	MembersCount int           `json:"members_count"`
 	ReposCount   int           `json:"repos_count"`

--- a/user.go
+++ b/user.go
@@ -1,21 +1,22 @@
 package gitbot
 
+// User object from github api
 type User struct {
 	Login             string `json:"login"`
-	Id                int    `json:"id"`
-	AvatarUrl         string `json:"avatar_url"`
-	GravatarId        string `json:"gravatar_id"`
-	Url               string `json:"url"`
-	HtmlUrl           string `json:"html_url"`
-	FollowersUrl      string `json:"followers_url"`
-	FollowingUrl      string `json:"following_url"`
-	GistsUrl          string `json:"gists_url"`
-	StarredUrl        string `json:"starred_url"`
-	SubscriptionsUrl  string `json:"subscriptions_url"`
-	OrganizationsUrl  string `json:"organizations_url"`
-	ReposUrl          string `json:"repos_url"`
-	EventsUrl         string `json:"events_url"`
-	ReceivedEventsUrl string `json:"received_events_url"`
+	ID                int    `json:"id"`
+	AvatarURL         string `json:"avatar_url"`
+	GravatarID        string `json:"gravatar_id"`
+	URL               string `json:"url"`
+	HTMLURL           string `json:"html_url"`
+	FollowersURL      string `json:"followers_url"`
+	FollowingURL      string `json:"following_url"`
+	GistsURL          string `json:"gists_url"`
+	StarredURL        string `json:"starred_url"`
+	SubscriptionsURL  string `json:"subscriptions_url"`
+	OrganizationsURL  string `json:"organizations_url"`
+	ReposURL          string `json:"repos_url"`
+	EventsURL         string `json:"events_url"`
+	ReceivedEventsURL string `json:"received_events_url"`
 	Type              string `json:"type"`
 	SiteAdmin         bool   `json:"site_admin"`
 }


### PR DESCRIPTION
Github suddenly changed their API to send both watch and star event on
star, so we now ignore watch events until they stop double-sending
things.

- Add Star payload and formatting
- Add explicit skips
- Add logging error if unknown event is given
- Fix go lint errors
- Change to use latest version of cinotify